### PR TITLE
Modification to allow site to be injected via a GET parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You will obviously have to put in your client_id, client_secret and public_key, 
 
 You will also need to specify a site option to uniquely identify the StackExchange site (e.g. `stackoverflow` or `superuser`) you wish to authenticate against.  A list of valid site api keys can be found at https://api.stackexchange.com/docs/sites. It's `stackoverflow` by default.
 
+If your application needs to be able to support multiple StackExchange sites, you can pass the site api key as the value for a GET parameter named sites (e.g. /auth/stackexchange?site=superuser)
+
 Now just follow the README at: https://github.com/intridea/omniauth
 
 ## Supported Rubies

--- a/lib/omniauth/strategies/stackexchange.rb
+++ b/lib/omniauth/strategies/stackexchange.rb
@@ -54,7 +54,7 @@ module OmniAuth
       end
 
       def site
-        options.site || 'stackoverflow'
+        request.env['omniauth.params']['site'] || options.site || 'stackoverflow'
       end
     end
   end


### PR DESCRIPTION
As we discussed the other day, here is a change that will allow the site to be injected via a GET parameter, thus allowing multiple sites to be supported by the GEM concurrently
