### PR TITLE
Add callback url option to fix regression for OAuth2 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.2.1 (September 22, 2015) ##
 
+## Bug fix
+* Fixes regression in omniauth-oauth2 v1.4.0 by [intridea/omniauth-oauth2@85fdbe1](https://github.com/intridea/omniauth-oauth2/commit/85fdbe1)
+
+## 0.2.1 (September 22, 2015) ##
+
 ### enhancements
  * Throw omniauth exception when user is not registered on StackExchange so you can rescue it in your app (by [@yimajo](https://github.com/yimajo))
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,26 @@ gem 'omniauth-stackexchange'
 You can pull them in directly from github e.g.:
 
 ```ruby
-gem 'omniauth-stackexchange', :git => 'https://github.com/nashby/omniauth-stackexchange.git'
+gem 'omniauth-stackexchange', git: 'https://github.com/nashby/omniauth-stackexchange.git'
 ```
 
 Once these are in, you need to add the following to your `config/initializers/omniauth.rb`:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :stackexchange, "client_id", "client_secret", public_key: "key", site: 'stackoverflow'
+  provider :stackexchange, 'client_id', 'client_secret', public_key: "key", site: 'stackoverflow'
 end
 ```
 
-You will obviously have to put in your client_id, client_secret and public_key, which you get when you register your app with StackExchange (they call them Client Id, Client Secret and Key).
+or with Devise to your `config/initializers/devise.rb`
+
+```ruby
+  config.omniauth :meetup, ENV['client_id'], ENV['client_secret'], callback_url: 'http://example.com/users/auth/stackexchange/callback'
+```
+**Starting from version 1.4 in omniauth-oauth2 you must provide same callback url you have provided on API dashboard otherwise authentication won't work.**
+
+
+You will obviously have to put in your client_id, client_secret and public_key, which you get when you register your app with [StackExchange](https://stackapps.com/apps) (they call them Client Id, Client Secret and Key).
 
 You will also need to specify a site option to uniquely identify the StackExchange site (e.g. `stackoverflow` or `superuser`) you wish to authenticate against.  A list of valid site api keys can be found at https://api.stackexchange.com/docs/sites. It's `stackoverflow` by default.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Once these are in, you need to add the following to your `config/initializers/om
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :stackexchange, 'client_id', 'client_secret', public_key: "key", site: 'stackoverflow'
+  provider :stackexchange, 'client_id', 'client_secret', public_key: 'key', site: 'stackoverflow'
 end
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
 require 'rake/testtask'
 Rake::TestTask.new do |t|
@@ -8,4 +8,4 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
-task :default => :test
+task default: :test

--- a/lib/omniauth-stackexchange/version.rb
+++ b/lib/omniauth-stackexchange/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module StackExchange
-    VERSION = "0.2.1"
+    VERSION = '0.2.1'.freeze
   end
 end

--- a/lib/omniauth-stackexchange/version.rb
+++ b/lib/omniauth-stackexchange/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module StackExchange
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end

--- a/lib/omniauth/strategies/stackexchange.rb
+++ b/lib/omniauth/strategies/stackexchange.rb
@@ -61,6 +61,12 @@ module OmniAuth
           'stackoverflow'
       end
 
+      def callback_url
+        # Fixes regression in omniauth-oauth2 v1.4.0 by
+        # https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
+        options[:callback_url] || (full_host + script_name + callback_path)
+      end
+
       def callback_phase
         super
       rescue NotRegisteredForStackExchangeSiteError => e

--- a/lib/omniauth/strategies/stackexchange.rb
+++ b/lib/omniauth/strategies/stackexchange.rb
@@ -2,18 +2,16 @@ require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
+    # Oauth2 strategy for StackExchange sites
     class StackExchange < OmniAuth::Strategies::OAuth2
       class NotRegisteredForStackExchangeSiteError < StandardError; end
 
-      option :client_options, {
-        :site => 'https://api.stackexchange.com/2.0',
-        :authorize_url => 'https://stackexchange.com/oauth',
-        :token_url => 'https://stackexchange.com/oauth/access_token'
-      }
+      option :client_options,
+             site: 'https://api.stackexchange.com/2.0',
+             authorize_url: 'https://stackexchange.com/oauth',
+             token_url: 'https://stackexchange.com/oauth/access_token'
 
-      option :token_params, {
-        :parse => :query
-      }
+      option :token_params, parse: :query
 
       def request_phase
         super
@@ -32,14 +30,18 @@ module OmniAuth
       end
 
       extra do
-        { :raw_info => raw_info }
+        { raw_info: raw_info }
       end
 
       def raw_info
-        @raw_info ||= access_token.get('me', :params => params).parsed['items'].first
+        @raw_info ||= access_token.get(
+          'me', params: params
+        ).parsed['items'].first
 
         unless @raw_info
-          raise NotRegisteredForStackExchangeSiteError, "User is not registered for requested StackExchange site (#{site})"
+          raise NotRegisteredForStackExchangeSiteError,
+                "User is not registered for requested
+                StackExchange site (#{site})"
         end
 
         @raw_info
@@ -47,14 +49,16 @@ module OmniAuth
 
       def params
         {
-          :site => site,
-          :access_token => access_token.token,
-          :key => options.public_key
+          site: site,
+          access_token: access_token.token,
+          key: options.public_key
         }
       end
 
       def site
-        request.env['omniauth.params']['site'] || options.site || 'stackoverflow'
+        request.env['omniauth.params']['site'] ||
+          options.site ||
+          'stackoverflow'
       end
 
       def callback_phase

--- a/omniauth-stackexchange.gemspec
+++ b/omniauth-stackexchange.gemspec
@@ -2,17 +2,17 @@
 require File.expand_path('../lib/omniauth-stackexchange/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Vasiliy Ermolovich"]
-  gem.email         = ["younash@gmail.com"]
-  gem.description   = %q{StackExchange OAuth strategy for OmniAuth}
-  gem.summary       = %q{StackExchange OAuth strategy for OmniAuth}
-  gem.homepage      = "https://github.com/nashby/omniauth-stackexchange"
+  gem.authors       = ['Vasiliy Ermolovich']
+  gem.email         = ['younash@gmail.com']
+  gem.description   = 'StackExchange OAuth strategy for OmniAuth'
+  gem.summary       = 'StackExchange OAuth strategy for OmniAuth'
+  gem.homepage      = 'https://github.com/nashby/omniauth-stackexchange'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "omniauth-stackexchange"
-  gem.require_paths = ["lib"]
+  gem.name          = 'omniauth-stackexchange'
+  gem.require_paths = ['lib']
   gem.version       = Omniauth::StackExchange::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.0'

--- a/test/stackexchange_test.rb
+++ b/test/stackexchange_test.rb
@@ -6,7 +6,7 @@ describe OmniAuth::Strategies::StackExchange do
   end
 
   it 'has correct site' do
-    stackexchange.options.client_options.site.must_equal("https://api.stackexchange.com/2.0")
+    stackexchange.options.client_options.site.must_equal('https://api.stackexchange.com/2.0')
   end
 
   it 'has correct authorize url' do


### PR DESCRIPTION
* Update old ruby syntax
* Fixes regression in omniauth-oauth2 v1.4.0 by intridea/omniauth-oauth2@85fdbe1 
* Update readme